### PR TITLE
feat: add email notifications for daily digests, reminders, and weekl…

### DIFF
--- a/.github/workflows/daily-digest-email.yml
+++ b/.github/workflows/daily-digest-email.yml
@@ -2,7 +2,7 @@ name: Daily Digest
 
 on:
   schedule:
-    - cron: "25 17 * * *" # Runs daily at 22:55 PM IST (UTC+5:30)
+    - cron: "30 13 * * *" # Runs daily at 7:00 PM IST (UTC+5:30)
   workflow_dispatch: # Allows manual runs for testing
 
 jobs:
@@ -12,7 +12,6 @@ jobs:
       - name: Send Daily Digest
         uses: fjogeleit/http-request-action@v1
         with:
-          url: "vercel.url/api/webhook/github/daily-digest"
+          url: "${{ secrets.VERCEL_URL }}/api/webhook/github/daily-digest"
           method: "POST"
-          customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"auth": "${{ secrets.AUTH_SECRET_TOKEN }}"}'
+          customHeaders: '{"Content-Type": "application/json", "Authorization": "Bearer ${{ secrets.GITHUB_WEBHOOK_SECRET }}"}'

--- a/.github/workflows/scheduled-email-reminder.yml
+++ b/.github/workflows/scheduled-email-reminder.yml
@@ -2,7 +2,7 @@ name: Scheduled Email Reminder
 
 on:
   schedule:
-    - cron: "25 14 * * *" # Runs daily at 19:55 PM IST (UTC+5:30)
+    - cron: "30 13 * * *" # Runs daily at 7:00 PM IST (UTC+5:30)
   workflow_dispatch: # Allows manual runs for testing
 
 jobs:
@@ -12,7 +12,6 @@ jobs:
       - name: Send Scheduled Email Reminder
         uses: fjogeleit/http-request-action@v1
         with:
-          url: "vercel.url/api/webhook/github/scheduled"
+          url: "${{ secrets.VERCEL_URL }}/api/webhook/github/scheduled"
           method: "POST"
-          customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"auth": "${{ secrets.AUTH_SECRET_TOKEN }}"}'
+          customHeaders: '{"Content-Type": "application/json", "Authorization": "Bearer ${{ secrets.GITHUB_WEBHOOK_SECRET }}"}'

--- a/.github/workflows/weekly-report-email.yml
+++ b/.github/workflows/weekly-report-email.yml
@@ -2,7 +2,7 @@ name: Weekly Report
 
 on:
   schedule:
-    - cron: "25 17 * * 0" # Runs daily at 22:55 PM IST (UTC+5:30) on Sunday
+    - cron: "30 13 * * 0" # Runs weekly at 7:00 PM IST (UTC+5:30) on Sunday
   workflow_dispatch: # Allows manual runs for testing
 
 jobs:
@@ -12,7 +12,6 @@ jobs:
       - name: Send Weekly Report
         uses: fjogeleit/http-request-action@v1
         with:
-          url: "vercel.url/api/webhook/github/weekly-report"
+          url: "${{ secrets.VERCEL_URL }}/api/webhook/github/weekly-report"
           method: "POST"
-          customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"auth": "${{ secrets.AUTH_SECRET_TOKEN }}"}'
+          customHeaders: '{"Content-Type": "application/json", "Authorization": "Bearer ${{ secrets.GITHUB_WEBHOOK_SECRET }}"}'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
     "source.organizeImports": "always",
     "source.removeUnusedImports": "always"
   },
-  "git.autofetch": true
+  "git.autofetch": true,
+  "zencoder.enableRepoIndexing": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "react-hook-form": "^7.57.0",
         "react-resizable-panels": "^3.0.2",
         "recharts": "^2.15.3",
+        "resend": "^4.5.2",
         "sonner": "^2.0.5",
         "svix": "^1.66.0",
         "tailwind-merge": "^3.3.0",
@@ -2689,6 +2690,37 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
+    "node_modules/@react-email/render": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.1.2.tgz",
+      "integrity": "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3",
+        "react-promise-suspense": "^0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -3406,6 +3438,15 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3446,6 +3487,61 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-case": {
@@ -3509,6 +3605,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -3607,6 +3715,12 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
     },
     "node_modules/fast-equals": {
       "version": "5.2.2",
@@ -3803,6 +3917,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/input-otp": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
@@ -3859,6 +4008,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",
@@ -4421,6 +4579,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4473,6 +4653,21 @@
       "license": "MIT",
       "peerDependencies": {
         "preact": ">=10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prisma": {
@@ -4582,6 +4777,15 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.0",
@@ -4723,6 +4927,18 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
     },
+    "node_modules/resend": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.5.2.tgz",
+      "integrity": "sha512-Uu11/254nkDFgVXQp18rzuz+9kRy5Ud4qr7FW98Yg4I4jkDKX1cr/8JKdrcJI753oknEq69/i3VTLbtrveQUGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4738,6 +4954,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-hook-form": "^7.57.0",
     "react-resizable-panels": "^3.0.2",
     "recharts": "^2.15.3",
+    "resend": "^4.5.2",
     "sonner": "^2.0.5",
     "svix": "^1.66.0",
     "tailwind-merge": "^3.3.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,3 +67,4 @@ model Reminder {
 
   @@index([userId, problemSlug])
 }
+

--- a/src/app/api/test-email/route.ts
+++ b/src/app/api/test-email/route.ts
@@ -1,0 +1,135 @@
+import { db } from "@/lib/db";
+import {
+    sendDailyDigestEmail,
+    sendReminderEmail,
+    sendUpcomingReminderEmail,
+    sendWeeklyReportEmail
+} from "@/lib/email";
+import { NextRequest } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { type, userId, reminderId } = await req.json();
+
+    switch (type) {
+      case 'reminder':
+        if (!reminderId) {
+          return new Response("reminderId is required for reminder emails", { status: 400 });
+        }
+        const result = await sendReminderEmail(reminderId);
+        return new Response(JSON.stringify({ success: true, result }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+      case 'daily-digest':
+        if (!userId) {
+          return new Response("userId is required for daily digest", { status: 400 });
+        }
+        const digestResult = await sendDailyDigestEmail(userId);
+        return new Response(JSON.stringify({ success: true, result: digestResult }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+      case 'weekly-report':
+        if (!userId) {
+          return new Response("userId is required for weekly report", { status: 400 });
+        }
+        const reportResult = await sendWeeklyReportEmail(userId);
+        return new Response(JSON.stringify({ success: true, result: reportResult }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+      case 'upcoming-reminder':
+        if (!userId) {
+          return new Response("userId is required for upcoming reminder", { status: 400 });
+        }
+        const upcomingResult = await sendUpcomingReminderEmail(userId);
+        return new Response(JSON.stringify({ success: true, result: upcomingResult }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+      default:
+        return new Response("Invalid email type. Use: reminder, daily-digest, weekly-report, or upcoming-reminder", {
+          status: 400
+        });
+    }
+  } catch (error) {
+    console.error("Test email error:", error);
+    return new Response(JSON.stringify({
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error'
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}
+
+// GET endpoint to list available test data
+export async function GET() {
+  try {
+    const users = await db.user.findMany({
+      select: {
+        externalUserId: true,
+        email: true,
+      },
+      take: 5
+    });
+
+    const reminders = await db.reminder.findMany({
+      select: {
+        id: true,
+        problemTitle: true,
+        scheduledDate: true,
+        user: {
+          select: {
+            email: true
+          }
+        }
+      },
+      take: 5
+    });
+
+    return new Response(JSON.stringify({
+      message: "Available test data",
+      users: users.map(u => ({ userId: u.externalUserId, email: u.email })),
+      reminders: reminders.map(r => ({
+        reminderId: r.id,
+        problemTitle: r.problemTitle,
+        userEmail: r.user.email,
+        scheduledDate: r.scheduledDate
+      })),
+      testExamples: {
+        reminder: {
+          method: "POST",
+          body: { type: "reminder", reminderId: "reminder_id_here" }
+        },
+        dailyDigest: {
+          method: "POST",
+          body: { type: "daily-digest", userId: "user_id_here" }
+        },
+        weeklyReport: {
+          method: "POST",
+          body: { type: "weekly-report", userId: "user_id_here" }
+        },
+        upcomingReminder: {
+          method: "POST",
+          body: { type: "upcoming-reminder", userId: "user_id_here" }
+        }
+      }
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    console.error("Error fetching test data:", error);
+    return new Response(JSON.stringify({ error: "Failed to fetch test data" }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}

--- a/src/app/api/webhook/github/daily-digest/route.ts
+++ b/src/app/api/webhook/github/daily-digest/route.ts
@@ -1,3 +1,52 @@
+import { db } from "@/lib/db";
+import { sendDailyDigestEmail } from "@/lib/email";
+
+async function getAllUsersWithDailyDigestEnabled() {
+  return await db.user.findMany({
+    where: {
+      sendDailyDigest: true,
+    },
+    select: {
+      externalUserId: true,
+      email: true,
+    },
+  });
+}
+
 export async function POST(req: Request) {
-  return new Response("Daily Digest!");
+  try {
+    // Verify the request is from GitHub Actions (optional security measure)
+    const authHeader = req.headers.get('authorization');
+    if (authHeader !== `Bearer ${process.env.GITHUB_WEBHOOK_SECRET}`) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const users = await getAllUsersWithDailyDigestEnabled();
+
+    if (users.length === 0) {
+      return new Response("No users with daily digest enabled", { status: 200 });
+    }
+
+    let sentCount = 0;
+    let errorCount = 0;
+
+    // Send daily digest to all users who have it enabled
+    for (const user of users) {
+      try {
+        await sendDailyDigestEmail(user.externalUserId);
+        sentCount++;
+      } catch (error) {
+        console.error(`Failed to send daily digest to ${user.email}:`, error);
+        errorCount++;
+      }
+    }
+
+    const message = `Processed ${users.length} users. Sent: ${sentCount}, Errors: ${errorCount}`;
+    console.log(message);
+
+    return new Response(message, { status: 200 });
+  } catch (error) {
+    console.error("Error sending daily digests:", error);
+    return new Response("Error sending daily digests", { status: 500 });
+  }
 }

--- a/src/app/api/webhook/github/scheduled/route.ts
+++ b/src/app/api/webhook/github/scheduled/route.ts
@@ -1,3 +1,66 @@
-export async function POST(req: Request) {
-  return new Response("Schedule!");
+
+import { db } from "@/lib/db";
+import { sendReminderEmail } from "@/lib/email";
+
+async function getUpcomingReminders() {
+  // Fetch reminders that are due now (within the current hour)
+  const now = new Date();
+  const oneHourFromNow = new Date(now.getTime() + 60 * 60 * 1000);
+
+  const reminders = await db.reminder.findMany({
+    where: {
+      scheduledDate: {
+        gte: now,
+        lte: oneHourFromNow,
+      },
+      reminderStatus: "UPCOMING",
+    },
+    orderBy: {
+      scheduledDate: "asc",
+    },
+    include: {
+      user: true,
+    },
+  });
+
+  return reminders;
 }
+
+export async function POST(req: Request) {
+  try {
+    // Verify the request is from GitHub Actions (optional security measure)
+    const authHeader = req.headers.get('authorization');
+    if (authHeader !== `Bearer ${process.env.GITHUB_WEBHOOK_SECRET}`) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const reminders = await getUpcomingReminders();
+
+    if (reminders.length === 0) {
+      return new Response("No upcoming reminders found", { status: 200 });
+    }
+
+    let sentCount = 0;
+    let errorCount = 0;
+
+    // Send emails for all due reminders
+    for (const reminder of reminders) {
+      try {
+        await sendReminderEmail(reminder.id);
+        sentCount++;
+      } catch (error) {
+        console.error(`Failed to send reminder ${reminder.id}:`, error);
+        errorCount++;
+      }
+    }
+
+    const message = `Processed ${reminders.length} reminders. Sent: ${sentCount}, Errors: ${errorCount}`;
+    console.log(message);
+
+    return new Response(message, { status: 200 });
+  } catch (error) {
+    console.error("Error processing reminders:", error);
+    return new Response("Error processing reminders", { status: 500 });
+  }
+}
+

--- a/src/app/api/webhook/github/weekly-report/route.ts
+++ b/src/app/api/webhook/github/weekly-report/route.ts
@@ -1,3 +1,52 @@
+import { db } from "@/lib/db";
+import { sendWeeklyReportEmail } from "@/lib/email";
+
+async function getAllUsersWithWeeklyReportEnabled() {
+  return await db.user.findMany({
+    where: {
+      sendWeeklyReport: true,
+    },
+    select: {
+      externalUserId: true,
+      email: true,
+    },
+  });
+}
+
 export async function POST(req: Request) {
-  return new Response("Weekly Report!");
+  try {
+    // Verify the request is from GitHub Actions (optional security measure)
+    const authHeader = req.headers.get('authorization');
+    if (authHeader !== `Bearer ${process.env.GITHUB_WEBHOOK_SECRET}`) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const users = await getAllUsersWithWeeklyReportEnabled();
+
+    if (users.length === 0) {
+      return new Response("No users with weekly report enabled", { status: 200 });
+    }
+
+    let sentCount = 0;
+    let errorCount = 0;
+
+    // Send weekly report to all users who have it enabled
+    for (const user of users) {
+      try {
+        await sendWeeklyReportEmail(user.externalUserId);
+        sentCount++;
+      } catch (error) {
+        console.error(`Failed to send weekly report to ${user.email}:`, error);
+        errorCount++;
+      }
+    }
+
+    const message = `Processed ${users.length} users. Sent: ${sentCount}, Errors: ${errorCount}`;
+    console.log(message);
+
+    return new Response(message, { status: 200 });
+  } catch (error) {
+    console.error("Error sending weekly reports:", error);
+    return new Response("Error sending weekly reports", { status: 500 });
+  }
 }

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -1,0 +1,317 @@
+interface ReminderEmailData {
+  userName: string;
+  problemTitle: string;
+  problemSlug: string;
+  problemDifficulty: 'EASY' | 'MEDIUM' | 'HARD';
+  scheduledDate: string;
+}
+
+interface DailyDigestData {
+  userName: string;
+  todayReminders: Array<{
+    problemTitle: string;
+    problemSlug: string;
+    problemDifficulty: 'EASY' | 'MEDIUM' | 'HARD';
+  }>;
+  upcomingReminders: Array<{
+    problemTitle: string;
+    problemSlug: string;
+    problemDifficulty: 'EASY' | 'MEDIUM' | 'HARD';
+    scheduledDate: string;
+  }>;
+}
+
+interface WeeklyReportData {
+  userName: string;
+  completedProblems: number;
+  totalReminders: number;
+  easyCompleted: number;
+  mediumCompleted: number;
+  hardCompleted: number;
+  weekStartDate: string;
+  weekEndDate: string;
+}
+
+const getDifficultyColor = (difficulty: string) => {
+  switch (difficulty) {
+    case 'EASY': return '#00b8a3';
+    case 'MEDIUM': return '#ffc01e';
+    case 'HARD': return '#ff375f';
+    default: return '#6b7280';
+  }
+};
+
+const getDifficultyBadge = (difficulty: string) => {
+  const color = getDifficultyColor(difficulty);
+  return `
+    <span style="
+      background-color: ${color};
+      color: white;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: bold;
+      text-transform: uppercase;
+    ">
+      ${difficulty}
+    </span>
+  `;
+};
+
+export const reminderEmailTemplate = (data: ReminderEmailData) => {
+  const leetcodeUrl = `https://leetcode.com/problems/${data.problemSlug}`;
+
+  return {
+    subject: `🎯 Time to solve: ${data.problemTitle}`,
+    html: `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>LeetCode Reminder</title>
+        </head>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; border-radius: 10px; text-align: center; margin-bottom: 30px;">
+            <h1 style="color: white; margin: 0; font-size: 28px;">🎯 LeetTrack Reminder</h1>
+            <p style="color: #f0f0f0; margin: 10px 0 0 0; font-size: 16px;">Time to sharpen your coding skills!</p>
+          </div>
+
+          <div style="background: #f8f9fa; padding: 25px; border-radius: 8px; margin-bottom: 25px;">
+            <h2 style="color: #2d3748; margin-top: 0;">Hi ${data.userName}! 👋</h2>
+            <p style="font-size: 16px; margin-bottom: 20px;">
+              It's time to tackle your scheduled problem:
+            </p>
+
+            <div style="background: white; padding: 20px; border-radius: 8px; border-left: 4px solid ${getDifficultyColor(data.problemDifficulty)};">
+              <h3 style="margin-top: 0; color: #2d3748; font-size: 20px;">${data.problemTitle}</h3>
+              <p style="margin: 10px 0;">
+                Difficulty: ${getDifficultyBadge(data.problemDifficulty)}
+              </p>
+              <p style="color: #666; font-size: 14px; margin: 10px 0;">
+                Scheduled for: ${data.scheduledDate}
+              </p>
+            </div>
+          </div>
+
+          <div style="text-align: center; margin: 30px 0;">
+            <a href="${leetcodeUrl}"
+               style="background: #ffa116; color: white; padding: 15px 30px; text-decoration: none; border-radius: 8px; font-weight: bold; font-size: 16px; display: inline-block; transition: background-color 0.3s;">
+              🚀 Solve Problem on LeetCode
+            </a>
+          </div>
+
+          <div style="background: #e2e8f0; padding: 20px; border-radius: 8px; margin-top: 30px;">
+            <h4 style="margin-top: 0; color: #2d3748;">💡 Quick Tips:</h4>
+            <ul style="color: #4a5568; padding-left: 20px;">
+              <li>Read the problem statement carefully</li>
+              <li>Think about edge cases</li>
+              <li>Start with a brute force solution, then optimize</li>
+              <li>Test your solution with the provided examples</li>
+            </ul>
+          </div>
+
+          <div style="text-align: center; margin-top: 40px; padding-top: 20px; border-top: 1px solid #e2e8f0; color: #666; font-size: 14px;">
+            <p>Happy coding! 🎉</p>
+            <p style="margin: 5px 0;">
+              <a href="#" style="color: #667eea; text-decoration: none;">Manage your reminders</a> |
+              <a href="#" style="color: #667eea; text-decoration: none;">Unsubscribe</a>
+            </p>
+          </div>
+        </body>
+      </html>
+    `,
+    text: `
+      Hi ${data.userName}!
+
+      It's time to tackle your scheduled LeetCode problem:
+
+      Problem: ${data.problemTitle}
+      Difficulty: ${data.problemDifficulty}
+      Scheduled for: ${data.scheduledDate}
+
+      Solve it here: ${leetcodeUrl}
+
+      Happy coding!
+      LeetTrack Team
+    `
+  };
+};
+
+export const dailyDigestTemplate = (data: DailyDigestData) => {
+  return {
+    subject: `📊 Your Daily LeetCode Digest - ${data.todayReminders.length} problems today`,
+    html: `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Daily Digest</title>
+        </head>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <div style="background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%); padding: 30px; border-radius: 10px; text-align: center; margin-bottom: 30px;">
+            <h1 style="color: white; margin: 0; font-size: 28px;">📊 Daily Digest</h1>
+            <p style="color: #f0f0f0; margin: 10px 0 0 0; font-size: 16px;">Your coding journey summary</p>
+          </div>
+
+          <div style="background: #f8f9fa; padding: 25px; border-radius: 8px; margin-bottom: 25px;">
+            <h2 style="color: #2d3748; margin-top: 0;">Good morning, ${data.userName}! ☀️</h2>
+
+            ${data.todayReminders.length > 0 ? `
+              <h3 style="color: #2d3748; border-bottom: 2px solid #4facfe; padding-bottom: 10px;">🎯 Today's Problems (${data.todayReminders.length})</h3>
+              ${data.todayReminders.map(problem => `
+                <div style="background: white; padding: 15px; border-radius: 8px; margin: 10px 0; border-left: 4px solid ${getDifficultyColor(problem.problemDifficulty)};">
+                  <h4 style="margin: 0 0 5px 0; color: #2d3748;">${problem.problemTitle}</h4>
+                  <p style="margin: 5px 0;">
+                    ${getDifficultyBadge(problem.problemDifficulty)}
+                  </p>
+                  <a href="https://leetcode.com/problems/${problem.problemSlug}"
+                     style="color: #4facfe; text-decoration: none; font-size: 14px;">
+                    View Problem →
+                  </a>
+                </div>
+              `).join('')}
+            ` : `
+              <div style="background: white; padding: 20px; border-radius: 8px; text-align: center; color: #666;">
+                <p>🎉 No problems scheduled for today! Take a well-deserved break or explore new challenges.</p>
+              </div>
+            `}
+
+            ${data.upcomingReminders.length > 0 ? `
+              <h3 style="color: #2d3748; border-bottom: 2px solid #00f2fe; padding-bottom: 10px; margin-top: 30px;">📅 Upcoming This Week</h3>
+              ${data.upcomingReminders.slice(0, 3).map(problem => `
+                <div style="background: white; padding: 15px; border-radius: 8px; margin: 10px 0; border-left: 4px solid #e2e8f0;">
+                  <h4 style="margin: 0 0 5px 0; color: #2d3748;">${problem.problemTitle}</h4>
+                  <p style="margin: 5px 0; font-size: 14px; color: #666;">
+                    ${getDifficultyBadge(problem.problemDifficulty)} • ${problem.scheduledDate}
+                  </p>
+                </div>
+              `).join('')}
+            ` : ''}
+          </div>
+
+          <div style="text-align: center; margin-top: 40px; padding-top: 20px; border-top: 1px solid #e2e8f0; color: #666; font-size: 14px;">
+            <p>Keep up the great work! 💪</p>
+            <p style="margin: 5px 0;">
+              <a href="#" style="color: #4facfe; text-decoration: none;">View Dashboard</a> |
+              <a href="#" style="color: #4facfe; text-decoration: none;">Manage Settings</a>
+            </p>
+          </div>
+        </body>
+      </html>
+    `,
+    text: `
+      Good morning, ${data.userName}!
+
+      Today's Problems (${data.todayReminders.length}):
+      ${data.todayReminders.map(p => `- ${p.problemTitle} (${p.problemDifficulty})`).join('\n')}
+
+      ${data.upcomingReminders.length > 0 ? `
+      Upcoming This Week:
+      ${data.upcomingReminders.slice(0, 3).map(p => `- ${p.problemTitle} (${p.problemDifficulty}) - ${p.scheduledDate}`).join('\n')}
+      ` : ''}
+
+      Keep coding!
+      LeetTrack Team
+    `
+  };
+};
+
+export const weeklyReportTemplate = (data: WeeklyReportData) => {
+  const completionRate = data.totalReminders > 0 ? Math.round((data.completedProblems / data.totalReminders) * 100) : 0;
+
+  return {
+    subject: `📈 Your Weekly Coding Report - ${data.completedProblems} problems solved!`,
+    html: `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Weekly Report</title>
+        </head>
+        <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <div style="background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%); padding: 30px; border-radius: 10px; text-align: center; margin-bottom: 30px;">
+            <h1 style="color: #2d3748; margin: 0; font-size: 28px;">📈 Weekly Report</h1>
+            <p style="color: #4a5568; margin: 10px 0 0 0; font-size: 16px;">${data.weekStartDate} - ${data.weekEndDate}</p>
+          </div>
+
+          <div style="background: #f8f9fa; padding: 25px; border-radius: 8px; margin-bottom: 25px;">
+            <h2 style="color: #2d3748; margin-top: 0;">Great work this week, ${data.userName}! 🎉</h2>
+
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin: 20px 0;">
+              <div style="background: white; padding: 20px; border-radius: 8px; text-align: center; border: 2px solid #48bb78;">
+                <h3 style="margin: 0; color: #48bb78; font-size: 32px;">${data.completedProblems}</h3>
+                <p style="margin: 5px 0 0 0; color: #666; font-size: 14px;">Problems Solved</p>
+              </div>
+              <div style="background: white; padding: 20px; border-radius: 8px; text-align: center; border: 2px solid #4299e1;">
+                <h3 style="margin: 0; color: #4299e1; font-size: 32px;">${completionRate}%</h3>
+                <p style="margin: 5px 0 0 0; color: #666; font-size: 14px;">Completion Rate</p>
+              </div>
+            </div>
+
+            <h3 style="color: #2d3748; margin: 30px 0 15px 0;">📊 Difficulty Breakdown</h3>
+            <div style="background: white; padding: 20px; border-radius: 8px;">
+              <div style="display: flex; justify-content: space-between; align-items: center; margin: 10px 0; padding: 10px; background: #f0fff4; border-radius: 6px;">
+                <span style="font-weight: bold;">Easy</span>
+                <span style="background: #00b8a3; color: white; padding: 4px 12px; border-radius: 20px; font-weight: bold;">${data.easyCompleted}</span>
+              </div>
+              <div style="display: flex; justify-content: space-between; align-items: center; margin: 10px 0; padding: 10px; background: #fffbf0; border-radius: 6px;">
+                <span style="font-weight: bold;">Medium</span>
+                <span style="background: #ffc01e; color: white; padding: 4px 12px; border-radius: 20px; font-weight: bold;">${data.mediumCompleted}</span>
+              </div>
+              <div style="display: flex; justify-content: space-between; align-items: center; margin: 10px 0; padding: 10px; background: #fff5f5; border-radius: 6px;">
+                <span style="font-weight: bold;">Hard</span>
+                <span style="background: #ff375f; color: white; padding: 4px 12px; border-radius: 20px; font-weight: bold;">${data.hardCompleted}</span>
+              </div>
+            </div>
+          </div>
+
+          <div style="background: #e6fffa; padding: 20px; border-radius: 8px; border-left: 4px solid #38b2ac;">
+            <h4 style="margin-top: 0; color: #2d3748;">🎯 Keep the momentum going!</h4>
+            <p style="color: #4a5568; margin-bottom: 0;">
+              ${completionRate >= 80 ?
+                "Outstanding performance! You're crushing your coding goals. 🚀" :
+                completionRate >= 60 ?
+                "Great progress! You're building a solid coding habit. 💪" :
+                "Every problem solved is progress. Keep pushing forward! 🌟"
+              }
+            </p>
+          </div>
+
+          <div style="text-align: center; margin-top: 40px; padding-top: 20px; border-top: 1px solid #e2e8f0; color: #666; font-size: 14px;">
+            <p>Here's to another productive week! 🎊</p>
+            <p style="margin: 5px 0;">
+              <a href="#" style="color: #38b2ac; text-decoration: none;">View Detailed Stats</a> |
+              <a href="#" style="color: #38b2ac; text-decoration: none;">Set New Goals</a>
+            </p>
+          </div>
+        </body>
+      </html>
+    `,
+    text: `
+      Weekly Report for ${data.userName}
+      ${data.weekStartDate} - ${data.weekEndDate}
+
+      📊 Your Stats:
+      - Problems Solved: ${data.completedProblems}
+      - Completion Rate: ${completionRate}%
+
+      Difficulty Breakdown:
+      - Easy: ${data.easyCompleted}
+      - Medium: ${data.mediumCompleted}
+      - Hard: ${data.hardCompleted}
+
+      ${completionRate >= 80 ?
+        "Outstanding performance! You're crushing your coding goals." :
+        completionRate >= 60 ?
+        "Great progress! You're building a solid coding habit." :
+        "Every problem solved is progress. Keep pushing forward!"
+      }
+
+      Keep coding!
+      LeetTrack Team
+    `
+  };
+};

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,313 @@
+import { db } from "@/lib/db";
+import {
+  dailyDigestTemplate,
+  reminderEmailTemplate,
+  weeklyReportTemplate
+} from "@/lib/email-templates";
+import { Resend } from "resend";
+
+const resend = new Resend(process.env.RESEND_API_KEY!);
+
+interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export async function sendEmail({ to, subject, html, text }: SendEmailOptions) {
+  try {
+    const msg = await resend.emails.send({
+      from: process.env.FROM_EMAIL!,
+      to,
+      subject,
+      html,
+      text,
+    });
+    console.log("Resend response:", msg);
+    return msg;
+  } catch (err) {
+    console.error("Resend sendEmail error:", err);
+    throw err;
+  }
+}
+
+// Send individual reminder email
+export async function sendReminderEmail(reminderId: string) {
+  try {
+    const reminder = await db.reminder.findUnique({
+      where: { id: reminderId },
+      include: { user: true }
+    });
+
+    if (!reminder) {
+      throw new Error("Reminder not found");
+    }
+
+    // Check if user wants email reminders
+    if (!reminder.user.sendEmailReminder) {
+      console.log(`User ${reminder.user.email} has disabled email reminders`);
+      return null;
+    }
+
+    const emailData = {
+      userName: reminder.user.email.split('@')[0], // Use email prefix as name for now
+      problemTitle: reminder.problemTitle,
+      problemSlug: reminder.problemSlug,
+      problemDifficulty: reminder.problemDifficulty as 'EASY' | 'MEDIUM' | 'HARD',
+      scheduledDate: reminder.scheduledDate.toLocaleDateString('en-US', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      })
+    };
+
+    const template = reminderEmailTemplate(emailData);
+
+    const result = await sendEmail({
+      to: reminder.user.email,
+      subject: template.subject,
+      html: template.html,
+      text: template.text
+    });
+
+    // Update reminder status to PENDING
+    await db.reminder.update({
+      where: { id: reminderId },
+      data: { reminderStatus: 'PENDING' }
+    });
+
+    console.log(`Reminder email sent to ${reminder.user.email} for problem: ${reminder.problemTitle}`);
+    return result;
+  } catch (error) {
+    console.error("Error sending reminder email:", error);
+    throw error;
+  }
+}
+
+// Send daily digest email
+export async function sendDailyDigestEmail(userId: string) {
+  try {
+    const user = await db.user.findUnique({
+      where: { externalUserId: userId },
+      include: {
+        reminder: {
+          where: {
+            scheduledDate: {
+              gte: new Date(new Date().setHours(0, 0, 0, 0)),
+              lt: new Date(new Date().setHours(23, 59, 59, 999))
+            }
+          }
+        }
+      }
+    });
+
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    // Check if user wants daily digest
+    if (!user.sendDailyDigest) {
+      console.log(`User ${user.email} has disabled daily digest`);
+      return null;
+    }
+
+    // Get upcoming reminders for the next 7 days
+    const upcomingReminders = await db.reminder.findMany({
+      where: {
+        userId: user.externalUserId,
+        scheduledDate: {
+          gt: new Date(),
+          lte: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        }
+      },
+      orderBy: { scheduledDate: 'asc' }
+    });
+
+    const emailData = {
+      userName: user.email.split('@')[0],
+      todayReminders: user.reminder.map(r => ({
+        problemTitle: r.problemTitle,
+        problemSlug: r.problemSlug,
+        problemDifficulty: r.problemDifficulty as 'EASY' | 'MEDIUM' | 'HARD'
+      })),
+      upcomingReminders: upcomingReminders.map(r => ({
+        problemTitle: r.problemTitle,
+        problemSlug: r.problemSlug,
+        problemDifficulty: r.problemDifficulty as 'EASY' | 'MEDIUM' | 'HARD',
+        scheduledDate: r.scheduledDate.toLocaleDateString('en-US', {
+          weekday: 'short',
+          month: 'short',
+          day: 'numeric'
+        })
+      }))
+    };
+
+    const template = dailyDigestTemplate(emailData);
+
+    const result = await sendEmail({
+      to: user.email,
+      subject: template.subject,
+      html: template.html,
+      text: template.text
+    });
+
+    console.log(`Daily digest sent to ${user.email}`);
+    return result;
+  } catch (error) {
+    console.error("Error sending daily digest:", error);
+    throw error;
+  }
+}
+
+// Send weekly report email
+export async function sendWeeklyReportEmail(userId: string) {
+  try {
+    const user = await db.user.findUnique({
+      where: { externalUserId: userId }
+    });
+
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    // Check if user wants weekly report
+    if (!user.sendWeeklyReport) {
+      console.log(`User ${user.email} has disabled weekly report`);
+      return null;
+    }
+
+    // Calculate week start and end dates
+    const now = new Date();
+    const weekStart = new Date(now.setDate(now.getDate() - now.getDay()));
+    weekStart.setHours(0, 0, 0, 0);
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekStart.getDate() + 6);
+    weekEnd.setHours(23, 59, 59, 999);
+
+    // Get completed reminders for this week
+    const completedReminders = await db.reminder.findMany({
+      where: {
+        userId: user.externalUserId,
+        reminderStatus: 'COMPLETED',
+        updatedAt: {
+          gte: weekStart,
+          lte: weekEnd
+        }
+      }
+    });
+
+    // Get total reminders for this week
+    const totalReminders = await db.reminder.count({
+      where: {
+        userId: user.externalUserId,
+        scheduledDate: {
+          gte: weekStart,
+          lte: weekEnd
+        }
+      }
+    });
+
+    // Count by difficulty
+    const easyCompleted = completedReminders.filter(r => r.problemDifficulty === 'EASY').length;
+    const mediumCompleted = completedReminders.filter(r => r.problemDifficulty === 'MEDIUM').length;
+    const hardCompleted = completedReminders.filter(r => r.problemDifficulty === 'HARD').length;
+
+    const emailData = {
+      userName: user.email.split('@')[0],
+      completedProblems: completedReminders.length,
+      totalReminders,
+      easyCompleted,
+      mediumCompleted,
+      hardCompleted,
+      weekStartDate: weekStart.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric'
+      }),
+      weekEndDate: weekEnd.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric'
+      })
+    };
+
+    const template = weeklyReportTemplate(emailData);
+
+    const result = await sendEmail({
+      to: user.email,
+      subject: template.subject,
+      html: template.html,
+      text: template.text
+    });
+
+    console.log(`Weekly report sent to ${user.email}`);
+    return result;
+  } catch (error) {
+    console.error("Error sending weekly report:", error);
+    throw error;
+  }
+}
+
+// Send upcoming reminder notification (for reminders due in next 24 hours)
+export async function sendUpcomingReminderEmail(userId: string) {
+  try {
+    const user = await db.user.findUnique({
+      where: { externalUserId: userId }
+    });
+
+    if (!user || !user.sendUpcomingReminder) {
+      return null;
+    }
+
+    // Get reminders due in next 24 hours
+    const upcomingReminders = await db.reminder.findMany({
+      where: {
+        userId: user.externalUserId,
+        reminderStatus: 'UPCOMING',
+        scheduledDate: {
+          gte: new Date(),
+          lte: new Date(Date.now() + 24 * 60 * 60 * 1000)
+        }
+      },
+      orderBy: { scheduledDate: 'asc' }
+    });
+
+    if (upcomingReminders.length === 0) {
+      return null;
+    }
+
+    const emailData = {
+      userName: user.email.split('@')[0],
+      todayReminders: [],
+      upcomingReminders: upcomingReminders.map(r => ({
+        problemTitle: r.problemTitle,
+        problemSlug: r.problemSlug,
+        problemDifficulty: r.problemDifficulty as 'EASY' | 'MEDIUM' | 'HARD',
+        scheduledDate: r.scheduledDate.toLocaleDateString('en-US', {
+          weekday: 'short',
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit'
+        })
+      }))
+    };
+
+    const template = dailyDigestTemplate(emailData);
+
+    const result = await sendEmail({
+      to: user.email,
+      subject: `🔔 ${upcomingReminders.length} reminder${upcomingReminders.length > 1 ? 's' : ''} coming up!`,
+      html: template.html,
+      text: template.text
+    });
+
+    console.log(`Upcoming reminder notification sent to ${user.email}`);
+    return result;
+  } catch (error) {
+    console.error("Error sending upcoming reminder email:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
…y reports

- Added new email templates for reminder, daily digest, and weekly report emails.
- Implemented functions to send emails for daily digests, reminders, and weekly reports using Resend service.
- Created API endpoints to handle GitHub webhook requests for sending daily digests and scheduled reminders.
- Introduced a test email endpoint to facilitate testing of email functionalities.
- Updated Prisma schema to include necessary fields for reminders.
- Added error handling and logging for email sending processes.
- Included logic to fetch users and reminders based on their preferences for email notifications.